### PR TITLE
Automatically accompany newly adopted sprites if unaccompanied.

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -61,6 +61,7 @@ export function sayluaApp(state = initialState, action) {
     case ADOPT:
       return Object.assign({}, state, {
         companions: state.companions.concat(action.companion),
+        activeCompanion: state.activeCompanion || action.companion,
       });
     case SET_ENCOUNTER:
       return Object.assign({}, state, {


### PR DESCRIPTION
This is a quick quality of life improvement to automatically accompany adopted sprites if you aren't currently accompanied.